### PR TITLE
Ruby を 4.0.3 から 4.0.5 にアップグレード

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby '4.0.5'
 
 gem 'rails', '~> 8.0'
 gem 'sqlite3', '>= 2.0'
-gem 'puma', '>= 6.0'
+gem 'puma', '>= 8.0'
 gem 'propshaft'
 gem 'importmap-rails'
 gem 'turbo-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -213,7 +213,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (7.2.0)
+    puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -356,7 +356,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   propshaft
-  puma (>= 6.0)
+  puma (>= 8.0)
   rails (~> 8.0)
   selenium-webdriver
   sqlite3 (>= 2.0)
@@ -447,7 +447,7 @@ CHECKSUMS
   propshaft (1.3.1) sha256=9acc664ef67e819ffa3d95bd7ad4c3623ea799110c5f4dee67fa7e583e74c392
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
-  puma (7.2.0) sha256=bf8ef4ab514a4e6d4554cb4326b2004eba5036ae05cf765cfe51aba9706a72a8
+  puma (8.0.2) sha256=c8ed871dfbbe66448ea9ffd46692342d9804d4071522b52b5331b7b6e7b686fb
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
   rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8


### PR DESCRIPTION
## 概要

Ruby のパッチバージョンを 4.0.3 から 4.0.5 にアップグレードします。

## 変更内容

- `.ruby-version`: `4.0.3` → `4.0.5`
- `Gemfile`: `ruby '4.0.3'` → `ruby '4.0.5'`
- `Gemfile.lock`: bundle install による更新
- `.github/workflows/ci.yml`: `ruby-version: '4.0.3'` → `'4.0.5'`

## 動作確認

- [x] `bundle install` 正常完了
- [x] `bundle exec rails test` 10件全パス（0 failures, 0 errors, 0 skips）