### PR TITLE
websocket-driver を 0.8.2 にアップデート

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,7 +326,7 @@ GEM
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
     websocket (1.2.11)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -502,7 +502,7 @@ CHECKSUMS
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
-  websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
+  websocket-driver (0.8.2) sha256=97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e
   zeitwerk (2.7.5) sha256=d8da92128c09ea6ec62c949011b00ed4a20242b255293dd66bf41545398f73dd


### PR DESCRIPTION
## 概要

- `websocket-driver` を 0.8.0 から 0.8.2 にアップデートしました。
- 不正な `Host` ヘッダーによりサーバーがクラッシュしうる DoS 脆弱性を修正します。

## 関連情報

- Dependabotアラート: https://github.com/maangie/action_text_sample/security/dependabot/378
- CVE-2026-61666 / GHSA-2x63-gw47-w4mm（Severity: High）

## テスト計画

- [x] `bundle update websocket-driver` を実行し、`Gemfile.lock` の差分が `websocket-driver` 関連のみであることを確認
- [ ] ローカルRuby環境の `error_highlight` バージョン不整合により `rails test` が実行できず（本変更とは無関係の既存問題のため、CI上での確認をお願いします）